### PR TITLE
Docker test

### DIFF
--- a/contracts/eosio.wps/CMakeLists.txt
+++ b/contracts/eosio.wps/CMakeLists.txt
@@ -19,4 +19,6 @@ set_target_properties(eosio.wps.wasm
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/abi/eosio.wps.abi" "${CMAKE_CURRENT_SOURCE_DIR}/bin/eosio.wps/eosio.wps.abi" COPYONLY)
 
+include_directories(${EOSIO_ROOT}/include)
+
 # install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION ${WASM_ROOT}/eosio.wasmsdk/include)

--- a/contracts/eosio.wps/src/proposal.cpp
+++ b/contracts/eosio.wps/src/proposal.cpp
@@ -2,7 +2,7 @@
 #include <eosio.wps/proposal.hpp>
 #include <eosio.wps/proposer.hpp>
 #include <eosio.wps/committee.hpp>
-
+#include <eosio/chain/core_symbol.hpp>
 // extern struct permission_level;
 // extern void require_auth(const permission_level& level);
 
@@ -53,7 +53,7 @@ namespace eosiowps {
 		eosio_assert(funding_goal.amount > 0, "must request positive amount" );
 
 		eosio_assert(funding_goal.symbol == asset().symbol, "symbol precision mismatch" );
-		eosio_assert(funding_goal.symbol == eosio::string_to_symbol(4, "EOS"), "symbol must be EOS");
+		eosio_assert(funding_goal.symbol == eosio::string_to_symbol(4, CORE_SYMBOL_NAME), "symbol must be " CORE_SYMBOL_NAME);
 
 		//initializing the proposer table
 		proposer_table proposers(_self, _self);
@@ -151,7 +151,7 @@ namespace eosiowps {
         // eosio_assert(duration <= wps_env.duration_of_voting, "duration should be less than duration_of_voting days.");
 
 		eosio_assert(funding_goal.symbol == asset().symbol, "symbol precision mismatch" );
-		eosio_assert(funding_goal.symbol == eosio::string_to_symbol(4, "EOS"), "symbol must be EOS");
+		eosio_assert(funding_goal.symbol == eosio::string_to_symbol(4, CORE_SYMBOL_NAME), "symbol must be " CORE_SYMBOL_NAME);
 
 		//initializing the proposer table
 		proposer_table proposers(_self, _self);

--- a/contracts/tests/CMakeLists.txt
+++ b/contracts/tests/CMakeLists.txt
@@ -12,7 +12,8 @@ endif()
 
 enable_testing()
 
-configure_file(${CMAKE_SOURCE_DIR}/contracts.hpp.in ${CMAKE_BINARY_DIR}/contracts.hpp)
+set(ROOT_DIR ${CMAKE_SOURCE_DIR}/..)
+configure_file(${CMAKE_SOURCE_DIR}/contracts.hpp.in ${CMAKE_SOURCE_DIR}/contracts.hpp)
 
 include_directories(${CMAKE_BINARY_DIR})
 

--- a/contracts/tests/test_wps.cpp
+++ b/contracts/tests/test_wps.cpp
@@ -1,4 +1,5 @@
 #include "test.hpp"
+#include <eosio/chain/core_symbol.hpp>
 
 class wps_tester : public tester {
 public:
@@ -46,7 +47,7 @@ public:
     produce_block();
     issue(N(eosio), core_from_string("100000000.0000"));
     produce_block();
-    transfer(N(eosio), N(eosio.wps), "100000.0000 EOS");
+    transfer(N(eosio), N(eosio.wps), "100000.0000 " CORE_SYMBOL_NAME);
     produce_block();
   }
 
@@ -353,7 +354,7 @@ BOOST_FIXTURE_TEST_CASE( flow_wps, wps_tester ) try {
   get_proposal(prop, N(proposer1));
   BOOST_TEST_MESSAGE(fc::json::to_pretty_string(prop));
 
-  // auto acc = get_account(N(proposer1), "4,EOS");
+  // auto acc = get_account(N(proposer1), "4," CORE_SYMBOL_NAME);
   // BOOST_TEST_MESSAGE(fc::json::to_pretty_string(acc));
   // 2 claimfunds success
   produce_block( fc::hours(30 * 24) );
@@ -410,7 +411,7 @@ BOOST_FIXTURE_TEST_CASE( flow_wps, wps_tester ) try {
   produce_blocks(1);
   BOOST_REQUIRE_EQUAL( wasm_assert_msg("Proposal not found in proposal table"), push_action(N(proposer1), N(claimfunds), mvo()("account", "proposer1")("proposal_id", 1)));
 
-  auto acc = get_account(N(proposer1), "4,EOS");
+  auto acc = get_account(N(proposer1), "4," CORE_SYMBOL_NAME);
   BOOST_TEST_MESSAGE(fc::json::to_pretty_string(acc));
 
   proposal_t prop_t;


### PR DESCRIPTION
In docker with container from eosio/eos-dev 1.2.1
```
cd wps-backend/contracts

./build.sh
```
No problem.

However, when I ran build/test/unit_test, it gave following error
```
Random number generator seeded to 1535454476
Running 5 test cases...
10 assert_exception: Assert Exception
wasm_file.is_open(): wasm file cannot be found
    {}
    thread-0  tester.cpp:33 read_wasm
/projects/wps-backend/contracts/tests/main.cpp(9): fatal error: in "committee_tests/manage_committee": Caught Unexpected Exception
10 assert_exception: Assert Exception
wasm_file.is_open(): wasm file cannot be found
    {}
    thread-0  tester.cpp:33 read_wasm
/projects/wps-backend/contracts/tests/main.cpp(9): fatal error: in "proposal_tests/manage_proposal": Caught Unexpected Exception
10 assert_exception: Assert Exception
wasm_file.is_open(): wasm file cannot be found
    {}
    thread-0  tester.cpp:33 read_wasm
/projects/wps-backend/contracts/tests/main.cpp(9): fatal error: in "proposer_tests/manage_proposer": Caught Unexpected Exception
10 assert_exception: Assert Exception
wasm_file.is_open(): wasm file cannot be found
    {}
    thread-0  tester.cpp:33 read_wasm
/projects/wps-backend/contracts/tests/main.cpp(9): fatal error: in "reviewer_tests/manage_reviewer": Caught Unexpected Exception
10 assert_exception: Assert Exception
wasm_file.is_open(): wasm file cannot be found
    {}
    thread-0  tester.cpp:33 read_wasm
/projects/wps-backend/contracts/tests/main.cpp(9): fatal error: in "wps_tests/flow_wps": Caught Unexpected Exception

*** 5 failures are detected in the test module "Master Test Suite"
```

I made some changes to 
```
contracts/tests/CMakeLists.txt
```
replaced
```
configure_file(${CMAKE_SOURCE_DIR}/contracts.hpp.in ${CMAKE_BINARY_DIR}/contracts.hpp)
```
with
```
set(ROOT_DIR ${CMAKE_SOURCE_DIR}/..)
configure_file(${CMAKE_SOURCE_DIR}/contracts.hpp.in ${CMAKE_SOURCE_DIR}/contracts.hpp)
```
rebuilt and ran, I got:

```
Random number generator seeded to 1535454351
Running 5 test cases...
3050003 eosio_assert_message_exception: eosio_assert_message assertion failure
assertion failure with message: symbol must be EOS
    {"s":"symbol must be EOS"}
    thread-0  wasm_interface.cpp:930 eosio_assert
pending console output: 
    {"console":""}
    thread-0  apply_context.cpp:61 exec_one
transaction_header: {"expiration":"2020-01-01T00:00:08","ref_block_num":6,"ref_block_prefix":2462007400,"max_net_usage_words":0,"max_cpu_usage_ms":0,"delay_sec":0}, billed_cpu_time_us: 2000
    {"header":{"expiration":"2020-01-01T00:00:08","ref_block_num":6,"ref_block_prefix":2462007400,"max_net_usage_words":0,"max_cpu_usage_ms":0,"delay_sec":0},"billed":2000}
    thread-0  tester.cpp:355 push_transaction

    {"code":"eosio.wps","acttype":"regproposal","auths":[{"actor":"proposer1","permission":"active"}],"data":{"proposer":"proposer1","id":1,"committee":"committee1","category":"emergency","subcategory":1,"title":"wps project title","summary":"wps proejct summary","project_img_url":"http://www.google.com","description":"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz","roadmap":"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz","duration":30,"members":["yepp4you","yepp4you2","yepp4you3"],"funding_goal":"10.0000 SYS","total_votes":0,"agree_votes":0,"disagree_votes":0,"status":1,"vote_start_time":0,"fund_start_time":0,"iteration_of_funding":0},"expiration":6,"delay_sec":0}
    thread-0  tester.cpp:427 push_action
rethrow
    {}
    thread-0  test_proposal.cpp:260 test_method
/projects/wps-backend/contracts/tests/main.cpp(9): fatal error: in "proposal_tests/manage_proposal": Caught Unexpected Exception
3050003 eosio_assert_message_exception: eosio_assert_message assertion failure
assertion failure with message: unable to find key
    {"s":"unable to find key"}
    thread-0  wasm_interface.cpp:930 eosio_assert
pending console output: 
    {"console":""}
    thread-0  apply_context.cpp:61 exec_one
transaction_header: {"expiration":"2020-01-01T00:00:08","ref_block_num":5,"ref_block_prefix":2117354780,"max_net_usage_words":0,"max_cpu_usage_ms":0,"delay_sec":0}, billed_cpu_time_us: 2000
    {"header":{"expiration":"2020-01-01T00:00:08","ref_block_num":5,"ref_block_prefix":2117354780,"max_net_usage_words":0,"max_cpu_usage_ms":0,"delay_sec":0},"billed":2000}
    thread-0  tester.cpp:355 push_transaction

    {"code":"eosio.token","acttype":"transfer","auths":[{"actor":"eosio","permission":"active"}],"data":{"from":"eosio","to":"eosio.wps","quantity":"100000.0000 EOS","memo":""},"expiration":6,"delay_sec":0}
    thread-0  tester.cpp:427 push_action
/projects/wps-backend/contracts/tests/main.cpp(9): fatal error: in "wps_tests/flow_wps": Caught Unexpected Exception
```

I updated
```
contracts/eosio.wps/CMakeLists.txt
contracts/eosio.wps/src/proposal.cpp
contracts/tests/test_wps.cpp
```
to reference the 'CORE_SYMBOL_NAME' from the eos source build, then everything worked.
